### PR TITLE
feat: fetcher

### DIFF
--- a/packages/create-ordi-app/template/src/client/routes/Food/components/Detail.tsx
+++ b/packages/create-ordi-app/template/src/client/routes/Food/components/Detail.tsx
@@ -1,5 +1,43 @@
-const Detail = () => {
-  return <p>detail</p>;
+import { useState } from "react";
+import { useFetch } from "ordijs/fetch";
+import { AppComponentType } from "ordijs/core";
+
+const Detail: AppComponentType = () => {
+  const [id, setId] = useState(1);
+
+  const { data: detail, loading } = useFetch({
+    fetchKey: ["todos", id],
+    fetcher: () =>
+      fetch(`https://jsonplaceholder.typicode.com/todos/${id}`).then((res) =>
+        res.json()
+      ),
+    ssr: false,
+    onSuccess(data) {
+      console.log("success", data);
+    },
+  });
+
+  return (
+    <>
+      {loading && <p>loading detail...</p>}
+      <p>content : {JSON.stringify(detail)}</p>
+      <button
+        onClick={() => {
+          setId(Math.floor(Math.random() * 40 + 1));
+        }}
+      >
+        random id
+      </button>
+
+      <button
+        onClick={() => {
+          setId(1);
+        }}
+      >
+        set id to 1
+      </button>
+    </>
+  );
 };
 
 export default Detail;

--- a/packages/create-ordi-app/template/src/client/routes/Food/index.tsx
+++ b/packages/create-ordi-app/template/src/client/routes/Food/index.tsx
@@ -1,34 +1,23 @@
-import { useState } from "react";
 import { AppComponentType } from "ordijs/core";
-import { useDataContext } from "ordijs/data";
 import { Helmet } from "ordijs/head";
 import { useHistory } from "ordijs/route";
-import lazy from "ordijs/lazy";
+import { useFetch } from "ordijs/fetch";
 
 import styles from "./index.css";
 import dummyPic from "./assets/dummy.jpg";
 
-const Detail = lazy(
-  () => import(/* webpackChunkName: "detail" */ "./components/Detail"),
-  {
-    ssr: true,
-  }
-);
+import Detail from "./components/Detail";
 
 const Food: AppComponentType = () => {
   const history = useHistory();
-  const [showDetail, setShowDetail] = useState(false);
 
-  const data = useDataContext() as unknown as {
-    todos: {
-      title: string;
-      id: number;
-    }[];
-  };
-
-  const toggleShowDetail = () => {
-    setShowDetail((e) => !e);
-  };
+  const {data :  todos = [], loading} = useFetch({
+    fetchKey: ["todos"],
+    fetcher: () =>
+      fetch("https://jsonplaceholder.typicode.com/todos").then((res) =>
+        res.json()
+      ).then(arr => arr.slice(1, 30))
+  });
 
   return (
     <>
@@ -38,16 +27,15 @@ const Food: AppComponentType = () => {
 
       <h3 className={styles.header}>Food</h3>
       <img src={dummyPic} alt="dummypic" />
-      {showDetail && <Detail />}
       <Detail />
-      <button onClick={toggleShowDetail}>toggle show detail</button>
       <button onClick={() => history.push("/person")}>go to person</button>
 
-      <ul>
-        {data.todos?.map((todo) => (
+      <ol>
+        {loading && <h5>loading list...</h5>}
+        {todos?.map((todo) => (
           <li key={todo.id}>{todo.title}</li>
         ))}
-      </ul>
+      </ol>
     </>
   );
 };

--- a/packages/ordi/cli/webpack/client/webpack.config.ts
+++ b/packages/ordi/cli/webpack/client/webpack.config.ts
@@ -21,7 +21,7 @@ export default mergeWithCustomize<Configuration>({
 
   output: {
     clean: true,
-    publicPath: process.env.HOST_CLIENT,
+    publicPath: `${process.env.HOST_CLIENT}/`,
     path: resolveCwd("build/client"),
   },
 

--- a/packages/ordi/fetch.js
+++ b/packages/ordi/fetch.js
@@ -1,0 +1,3 @@
+const useFetch = require("./build/shared/context/fetch/usecase/use-fetch").default;
+
+module.exports = useFetch;

--- a/packages/ordi/fetch.ts
+++ b/packages/ordi/fetch.ts
@@ -1,0 +1,1 @@
+export { useFetch } from "./build/shared/context/fetch/usecase/use-fetch";

--- a/packages/ordi/package.json
+++ b/packages/ordi/package.json
@@ -8,7 +8,8 @@
     "start": "node ./src/cli serve",
     "build": "rm -rf build && npm-run-all --parallel build:ts build:js",
     "build:ts": "pnpm tsc",
-    "build:js": "rm -rf build && babel src --out-dir build --extensions \".ts,.tsx\""
+    "build:js": "rm -rf build && babel src --out-dir build --extensions \".ts,.tsx\"",
+    "publish" : "pnpm run build && npm publish"
   },
   "bin": {
     "ordi": "./cli/index.js"

--- a/packages/ordi/package.json
+++ b/packages/ordi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ordijs",
   "private": false,
-  "version": "0.1.0-beta-1",
+  "version": "0.2.0-beta-1",
   "description": "Main Code in Beyond Framework",
   "main": "./build/server/main.js",
   "scripts": {

--- a/packages/ordi/src/@types/global.d.ts
+++ b/packages/ordi/src/@types/global.d.ts
@@ -1,5 +1,6 @@
 interface Window {
   __ORDI_DATA__: Record<string, unknown>;
+  __ORDI_FETCH__: Record<string, unknown>;
 }
 
 interface NodeModule {

--- a/packages/ordi/src/client/bootstrap.tsx
+++ b/packages/ordi/src/client/bootstrap.tsx
@@ -4,18 +4,22 @@ import { loadableReady } from "@loadable/component";
 
 import Routes from "../router";
 import ContextProvider from "../shared/context";
+import { FetchProvider } from "../shared/context/fetch";
 import App from "./_app";
 
 const app = (
   <BrowserRouter>
     <ContextProvider>
-      <App>
-        <Routes />
-      </App>
+      <FetchProvider>
+        <App>
+          <Routes />
+        </App>
+      </FetchProvider>
     </ContextProvider>
   </BrowserRouter>
 );
 
-const renderer = (id: HTMLElement | null) => loadableReady(() => ReactDOM.hydrate(app, id))
+const renderer = (id: HTMLElement | null) =>
+  loadableReady(() => ReactDOM.hydrate(app, id));
 
 renderer(document.getElementById("__ordi"));

--- a/packages/ordi/src/client/index.ts
+++ b/packages/ordi/src/client/index.ts
@@ -1,5 +1,5 @@
-const registerClient = async () => {
-  await import("./bootstrap");
+const registerClient =  () => {
+  require("./bootstrap")
 };
 
 export default registerClient;

--- a/packages/ordi/src/server/middleware/renderer/index.tsx
+++ b/packages/ordi/src/server/middleware/renderer/index.tsx
@@ -58,7 +58,7 @@ export default function rendererMiddleware(
         revalidate = _revalidate;
       }
 
-      const { status, html, redirect } = render({ req, routerProps });
+      const { status, html, redirect } = await render({ req, routerProps });
 
       if (status === 301) {
         reply.redirect(301, redirect);

--- a/packages/ordi/src/server/middleware/renderer/render.tsx
+++ b/packages/ordi/src/server/middleware/renderer/render.tsx
@@ -100,7 +100,6 @@ export default async function render({
     </ChunkExtractorManager>
   );
 
-  // const appHTML = renderToStaticMarkup(AppTree);
   const { html: appHTML, fetchState } = await getDataFromTree(AppTree);
 
   const body = renderDocument({

--- a/packages/ordi/src/server/utils/collector.ts
+++ b/packages/ordi/src/server/utils/collector.ts
@@ -1,0 +1,45 @@
+type PromiseFunc = () => Promise<unknown>;
+
+export type CollectorValue = {
+  addPromise: (key: string, promise: PromiseFunc) => void;
+  runAllPromise: () => Promise<void>;
+  getPromise: <T>(key: string) => T;
+  hasPromise: () => boolean;
+  getResolved: () => Record<string, unknown>;
+};
+
+const Collector = (): CollectorValue => {
+  let promises: Record<string, PromiseFunc> | undefined;
+
+  let resolved: Record<string, unknown> = {};
+
+  return {
+    addPromise(key, promise) {
+      if (!promises) promises = {};
+      promises[key] = promise;
+    },
+    getPromise<T>(key: string) {
+      return resolved[key] as T;
+    },
+    getResolved() {
+      return resolved;
+    },
+    hasPromise() {
+      return Boolean(promises);
+    },
+    async runAllPromise() {
+      if (!promises) return;
+
+      const tuplesPromise = Object.entries(promises);
+      for (const [key, promise] of tuplesPromise) {
+        try {
+          const result = await promise();
+          resolved[key] = result;
+        } catch {}
+      }
+      promises = undefined;
+    },
+  };
+};
+
+export default Collector;

--- a/packages/ordi/src/shared/context/data/index.tsx
+++ b/packages/ordi/src/shared/context/data/index.tsx
@@ -1,25 +1,23 @@
+import { createContext, useContext, useState } from "react";
+import type { PropsWithChildren } from "react";
+
 import { canUseDom } from "../../../utils/dom";
-import { createContext, useContext } from "react";
-import type { ReactNode, VFC } from "react";
 
 type Props = {
   data: Record<string, unknown>;
 };
 
-type ContextValue = Record<string, unknown>
+type ContextValue = Record<string, unknown>;
 
-export const DataContext = createContext<ContextValue| undefined>(undefined);
+export const DataContext = createContext<ContextValue | undefined>(undefined);
 
-export const DataProvider: VFC<Props & { children: ReactNode }> = ({
-  children,
-  data,
-}) => {
-  const initialData = canUseDom ? window.__ORDI_DATA__ : data;
+export const DataProvider = ({ children, data }: PropsWithChildren<Props>) => {
+  const [initialData] = useState(() =>
+    canUseDom ? window.__ORDI_DATA__ : data
+  );
 
   return (
-    <DataContext.Provider value={initialData}>
-      {children}
-    </DataContext.Provider>
+    <DataContext.Provider value={initialData}>{children}</DataContext.Provider>
   );
 };
 

--- a/packages/ordi/src/shared/context/fetch/index.tsx
+++ b/packages/ordi/src/shared/context/fetch/index.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState } from "react";
+import type { PropsWithChildren } from "react";
+
+import type { CollectorValue } from "../../../server/utils/collector";
+import { canUseDom } from "../../../utils/dom";
+
+export type { CollectorValue } from "../../../server/utils/collector";
+
+type Props = {
+  collector?: CollectorValue;
+};
+
+type ContextValue = {
+  collector?: CollectorValue;
+  data: Record<string, unknown>;
+};
+
+export const FetchContext = createContext<ContextValue | undefined>(undefined);
+
+export const FetchProvider = ({
+  children,
+  collector,
+}: PropsWithChildren<Props>) => {
+  const [data] = useState(() => {
+    if (canUseDom) return window.__ORDI_FETCH__;
+    // in SSR
+    return collector?.getResolved() || {};
+  });
+
+  return (
+    <FetchContext.Provider value={{ collector, data }}>
+      {children}
+    </FetchContext.Provider>
+  );
+};
+
+export const useFetchContext = () => {
+  const context = useContext(FetchContext);
+
+  if (!context) {
+    throw Error("using useFetchContext must under FetchProvider");
+  }
+
+  return context;
+};

--- a/packages/ordi/src/shared/context/fetch/usecase/use-fetch/index.ts
+++ b/packages/ordi/src/shared/context/fetch/usecase/use-fetch/index.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { UseFetch } from "./types";
+import { useFetchContext } from "../..";
+
+class InternalState {
+  private toQueryResultCache = new Map<string, any>();
+
+  public useFetch<Data = any>(args: UseFetch<Data>) {
+    const { ssr = true } = args;
+
+    const context = useFetchContext();
+
+    const initialLoad = useRef(true);
+
+    const fetchKey = JSON.stringify(args.fetchKey);
+    const ssrData = context?.data?.[fetchKey] as Data | undefined;
+
+    const [data, setData] = useState<Data | undefined>(
+      ssrData ?? args.initialData
+    );
+
+    const [loading, setLoading] = useState(() => {
+      /**
+       * @note if ssr, we check data is exists or not,
+       * if exists means it success to load in server, make loading is false
+       */
+      if (ssr) {
+        return !Boolean(data);
+      }
+      return true;
+    });
+
+    const [error, setError] = useState<Error | undefined>(undefined);
+
+    const fetcher = useCallback(async () => {
+      if (this.toQueryResultCache.has(fetchKey)) {
+        setData(this.toQueryResultCache.get(fetchKey));
+        return;
+      }
+
+      try {
+        setLoading(true);
+        const response = await args.fetcher();
+        if (args.onSuccess) args.onSuccess(response);
+        setData(response);
+        this.toQueryResultCache.set(fetchKey, response);
+      } catch (err) {
+        const _error = err instanceof Error ? err : Error(String(err));
+        if (args.onError) args.onError(_error);
+        setError(_error);
+      } finally {
+        setLoading(false);
+      }
+    }, [fetchKey]);
+
+    /**
+     * @note for runtime
+     */
+    useEffect(() => {
+      !initialLoad.current && fetcher();
+    }, [fetcher]);
+
+    /**
+     * @note if ssr failed load in server
+     */
+    useEffect(() => {
+      if (ssr && !data) {
+        fetcher().then(() => {
+          initialLoad.current = false;
+        });
+      }
+    }, []);
+
+    /**
+     * @note fetching in client
+     */
+
+    useEffect(() => {
+      if (!ssr) {
+        fetcher().then(() => {
+          initialLoad.current = false;
+        });
+      }
+    }, []);
+
+    if (!context) {
+      return { data: undefined, loading: true, error: undefined };
+    }
+
+    /**
+     * @note for now collector value is only from ssr
+     */
+
+    if (ssr && context.collector) {
+      const result = context.collector.getPromise(fetchKey);
+      if (!result) context.collector.addPromise(fetchKey, args.fetcher);
+    }
+
+    return useMemo(() => ({ data, loading, error }), [data, loading, error]);
+  }
+}
+
+const useInternalState = () => {
+  const [state] = useState(new InternalState());
+  return state;
+};
+
+export const useFetch = <Data = any>(args: UseFetch<Data>) =>
+  useInternalState().useFetch(args);

--- a/packages/ordi/src/shared/context/fetch/usecase/use-fetch/types.ts
+++ b/packages/ordi/src/shared/context/fetch/usecase/use-fetch/types.ts
@@ -1,0 +1,8 @@
+export interface UseFetch<Data> {
+  fetchKey: unknown[];
+  fetcher: () => Promise<Data>;
+  onSuccess?: (data: Data) => void;
+  onError?: (error: Error) => void;
+  initialData?: Data;
+  ssr?: boolean;
+}

--- a/packages/ordi/src/shared/context/html/index.tsx
+++ b/packages/ordi/src/shared/context/html/index.tsx
@@ -1,26 +1,29 @@
 import { createContext, useContext } from "react";
-import type { VFC, ReactNode } from "react";
+import type { PropsWithChildren } from "react";
 import type { HelmetData } from "react-helmet-async";
 import type { ChunkExtractor } from "@loadable/server";
 
 export type HtmlContextType = {
-  helmet: HelmetData['context']['helmet'];
+  helmet: HelmetData["context"]["helmet"];
   extractor: ChunkExtractor;
   html: string;
   routerProps: Record<string, unknown>;
+  fetchProps: Record<string, unknown>;
 };
 
 export const HtmlContext = createContext<HtmlContextType | undefined>(
   undefined
 );
 
-export const HtmlProvider: VFC<HtmlContextType & { children: ReactNode }> = (
-  props
+export const HtmlProvider= (
+  props: PropsWithChildren<HtmlContextType>
 ) => {
-  const { helmet, extractor, html, routerProps, children } = props;
+  const { helmet, extractor, html, routerProps, children, fetchProps } = props;
 
   return (
-    <HtmlContext.Provider value={{ helmet: helmet, extractor, html, routerProps }}>
+    <HtmlContext.Provider
+      value={{ helmet: helmet, extractor, html, routerProps, fetchProps }}
+    >
       {children}
     </HtmlContext.Provider>
   );

--- a/packages/ordi/src/shared/context/index.tsx
+++ b/packages/ordi/src/shared/context/index.tsx
@@ -15,7 +15,9 @@ const ContextProvider: VFC<Props> = ({
 }) => {
   return (
     <HelmetProvider context={helmetContext}>
-      <DataProvider data={routerProps}>{children}</DataProvider>
+      <DataProvider data={routerProps}>
+        {children}
+      </DataProvider>
     </HelmetProvider>
   );
 };

--- a/packages/ordi/src/shared/document/index.tsx
+++ b/packages/ordi/src/shared/document/index.tsx
@@ -20,7 +20,7 @@ export const Head = () => {
 };
 
 export const Scripts = () => {
-  const { extractor, routerProps } = useHtmlContext();
+  const { extractor, routerProps, fetchProps } = useHtmlContext();
 
   return (
     <>
@@ -29,6 +29,7 @@ export const Scripts = () => {
         dangerouslySetInnerHTML={{
           __html: `
           window.__ORDI_DATA__=${JSON.stringify(routerProps)}
+          window.__ORDI_FETCH__=${JSON.stringify(fetchProps)}
         `,
         }}
       ></script>


### PR DESCRIPTION
# Pull Request Template

## Description

This feature is inspiration from [useQuery](https://www.apollographql.com/docs/react/data/queries/#executing-a-query) from apollo hooks and [useQuery](https://tanstack.com/query/v4/docs/framework/react/reference/useQuery) from tanstack, in this framework we call `useFetch`. **useFetch** is being use for fetching data from api in SSR and Client.


### API
```ts
useFetch(args: Options);
```
#### Options
| Arguments   | Description                                         | Type     | Required |
| ----------- | --------------------------------------------------- | -------- | -------- |
| fetchKey    | unique identifier for each request                  | any[]    | true     |
| fetcher     | a api function to be called                         | function | true     |
| initialData | initial data                                        | any      | false    |
| ssr         | indicates it executes in server side or not         | boolean  | false    |
| onSuccess   | a success function when fetcher is success executes | function | false    |
| onError     | a error function when fetcher is success executes   | function | false    |


### Usage
```tsx
// SSR MODE
const {data :  todos = [], loading} = useFetch({
    fetchKey: ["todos"],
    fetcher: () =>
      fetch("https://jsonplaceholder.typicode.com/todos").then((res) =>
        res.json()
      ).then(arr => arr.slice(1, 30))
  });

// UI
return <ol>
  {loading && <h5>loading list...</h5>}
  {todos?.map((todo) => (
    <li key={todo.id}>{todo.title}</li>
  ))}
</ol>
```

### Notes
1. you can consume all resolved fetcher data through **useFetchContext()** (in server or client) **window.__ORDI_FETCH__** (in client)
